### PR TITLE
The steamboat Willie link is broken

### DIFF
--- a/data/feed.json
+++ b/data/feed.json
@@ -10,12 +10,6 @@
           "audioUrl": "https://archive.org/download/superman_the_mechanical_monsters/superman_the_mechanical_monsters_512kb.mp4"
         },
         {
-          "id": "track-steamboat",
-          "title": "Steamboat Willie",
-          "description": "The classic 1928 Disney cartoon featuring Mickey Mouse, now in the public domain.",
-          "audioUrl": "https://ia801400.us.archive.org/2/items/steamboat-willie-mickey/Steamboat%20Willie%20%281928%29.mp4"
-        },
-        {
           "id": "track-popeye",
           "title": "Popeye the Sailor Meets Sindbad the Sailor",
           "description": "A 1936 Popeye cartoon in the public domain, produced by Fleischer Studios.",
@@ -74,4 +68,4 @@
       ]
     }
   ]
-} 
+}


### PR DESCRIPTION
Fixes #2

Remove the entry for Steamboat Willie from the `data/feed.json` file.

* Remove the entry for "Steamboat Willie" from the "tracks" array in the "classic-cartoons" feed.
* Ensure the "tracks" array is still valid JSON after removal.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jmcpheron/did-you-hear-that/pull/3?shareId=8e67a2c0-cb90-416e-ae91-5f527f7708c3).