### PR TITLE
Add David and Goliath cartoon to Classic Cartoons feed

### DIFF
--- a/data/feed.json
+++ b/data/feed.json
@@ -20,6 +20,12 @@
           "title": "Skeleton Frolics",
           "description": "A 1937 animated cartoon by Ub Iwerks featuring dancing skeletons.",
           "audioUrl": "https://archive.org/download/pdcartooncollection/Skeleton%20Frolics%201937%20Ub%20Iwerks%5B1%5D.mp4"
+        },
+        {
+          "id": "track-david-goliath",
+          "title": "David and Goliath",
+          "description": "A public domain cartoon about the biblical story of David and Goliath. It's a Mellow Tune cartoon.",
+          "audioUrl": "https://ia800903.us.archive.org/11/items/DavidAndGoliath/DavidAndGoliath_512kb.mp4"
         }
       ]
     },


### PR DESCRIPTION
Fixes #4

Add 'David and Goliath' cartoon to the "Classic Cartoons" feed in `data/feed.json`.

* Add a new track entry for "David and Goliath" with the title "David and Goliath".
* Set the description to "A public domain cartoon about the biblical story of David and Goliath. It's a Mellow Tune cartoon."
* Set the audioUrl to "https://ia800903.us.archive.org/11/items/DavidAndGoliath/DavidAndGoliath_512kb.mp4".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jmcpheron/did-you-hear-that/pull/5?shareId=d74c1ae5-1bf4-4a0f-b210-93fda5a34a89).